### PR TITLE
restructured listeners. deprecated old listener.

### DIFF
--- a/core/src/main/java/com/ejar/dmb/core/jda/BotListener.java
+++ b/core/src/main/java/com/ejar/dmb/core/jda/BotListener.java
@@ -17,15 +17,13 @@ package com.ejar.dmb.core.jda;
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import net.dv8tion.jda.core.entities.User;
 import net.dv8tion.jda.core.events.ReadyEvent;
 import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.core.hooks.ListenerAdapter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Arrays;
-
+@Deprecated
 public class BotListener extends ListenerAdapter {
 
     private final Logger logger = LogManager.getLogger();
@@ -43,44 +41,14 @@ public class BotListener extends ListenerAdapter {
 
     }
 
+
+
     @Override
     public void onGuildMessageReceived(GuildMessageReceivedEvent event) {
 
         super.onGuildMessageReceived(event);
 
-        if (event.getAuthor().isBot()) {
 
-            return;
-
-        }
-
-        String[] msg = event.getMessage().getContentRaw().split("\\s+");
-
-        User userCandidate = event.getAuthor();
-
-        logger.debug("Guild message received from: {}, member: {}, content: {}",
-                userCandidate.getName(),
-                event.getMember(),
-                event.getMessage());
-
-        if (msg.length >= 1 && !msg[0].toLowerCase().equals("%dmb%")) {
-
-            return;
-
-        }
-
-        User current = DiscordConnector.getInstance().getControllingUser();
-
-        UserControlCaveats c = DiscordConnector.getInstance().setControllingUser(userCandidate);
-
-        String s = UserControlCaveats.getFailureContext(userCandidate, current, c);
-
-        event.getGuild().getTextChannelById(event.getMessage().getTextChannel().getId())
-                .sendMessage(s).queue();
-
-        DiscordConnector.getInstance().setWakeState(userCandidate);
-
-        String[] arguments = Arrays.copyOfRange(msg, 1, msg.length);
 
 
 

--- a/core/src/main/java/com/ejar/dmb/core/jda/BotMessageListener.java
+++ b/core/src/main/java/com/ejar/dmb/core/jda/BotMessageListener.java
@@ -1,0 +1,82 @@
+package com.ejar.dmb.core.jda;
+
+/*
+ * Discord Movie Bot
+ * Copyright (C) 2020  Evan R. Jaramillo
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import net.dv8tion.jda.core.entities.User;
+import net.dv8tion.jda.core.events.message.guild.GuildMessageReceivedEvent;
+import net.dv8tion.jda.core.hooks.ListenerAdapter;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Arrays;
+
+public class BotMessageListener extends ListenerAdapter {
+
+    private final Logger logger = LogManager.getLogger();
+
+    private final DiscordConnector connector;
+
+    public BotMessageListener() {
+
+        this.connector = DiscordConnector.getInstance();
+
+    }
+
+    @Override
+    public void onGuildMessageReceived(GuildMessageReceivedEvent event) {
+
+        super.onGuildMessageReceived(event);
+
+        if (event.getAuthor().isBot()) {
+
+            return;
+
+        }
+
+        String[] msg = event.getMessage().getContentRaw().split("\\s+");
+
+        User userCandidate = event.getAuthor();
+
+        logger.debug("Guild message received from: {}, member: {}, content: {}",
+                userCandidate.getName(),
+                event.getMember(),
+                event.getMessage());
+
+        if (msg.length >= 1 && !msg[0].toLowerCase().equals("%dmb%")) {
+
+            return;
+
+        }
+
+        User current = this.connector.getControllingUser();
+
+        UserControlCaveats c = this.connector.setControllingUser(userCandidate);
+
+        String s = UserControlCaveats.getFailureContext(userCandidate, current, c);
+
+        event.getGuild().getTextChannelById(event.getMessage().getTextChannel().getId())
+                .sendMessage(s).queue();
+
+        this.connector.setWakeState(userCandidate);
+
+        String[] arguments = Arrays.copyOfRange(msg, 1, msg.length);
+
+    }
+
+
+}

--- a/core/src/main/java/com/ejar/dmb/core/jda/DiscordConnector.java
+++ b/core/src/main/java/com/ejar/dmb/core/jda/DiscordConnector.java
@@ -48,6 +48,7 @@ public class DiscordConnector {
 
     private BotOptions options;
     private BotListener listener;
+    private BotMessageListener messageListener;
     private JDA jda;
 
     private ControllingUserFacilitator controllingUserFacilitator;
@@ -82,17 +83,17 @@ public class DiscordConnector {
 
         logger.info("Creating JDA instance...");
 
-
-            this.jda = new JDABuilder()
+        this.jda = new JDABuilder()
                     .setToken(this.options.getToken())
                     .setCompressionEnabled(this.options.isCompressionEnabled())
                     .setAutoReconnect(this.options.isAutoReconnect())
                     .build()
                     .awaitReady();
 
-            this.listener = new BotListener();
+        this.setSleepState();
 
-            this.jda.addEventListener(this.listener);
+        this.messageListener = new BotMessageListener();
+        this.jda.addEventListener(this.messageListener);
 
     }
 

--- a/core/src/main/java/com/ejar/dmb/core/jda/UserControlCaveats.java
+++ b/core/src/main/java/com/ejar/dmb/core/jda/UserControlCaveats.java
@@ -62,7 +62,7 @@ public enum UserControlCaveats {
                         .append(current)
                         .append("' to '")
                         .append(candidate)
-                        .append(".");
+                        .append("'.");
 
                 break;
 

--- a/core/src/main/java/com/ejar/dmb/core/version/Version.java
+++ b/core/src/main/java/com/ejar/dmb/core/version/Version.java
@@ -13,6 +13,6 @@ public abstract class Version {
 
     public static final String BUILD_VERSION = "0.5";
     public static final String POM_VERSION   = "1.0-SNAPSHOT";
-    public static final String BUILD_TIME    = "2020-05-31T00:29:58Z";
+    public static final String BUILD_TIME    = "2020-05-31T16:01:45Z";
 
 }


### PR DESCRIPTION
The ready event was never getting fired because the JDA instance was built synchronously. Restructured to split up listener implementations, and moved ready to after JDA instantiation.